### PR TITLE
fix: correct 'Shippling' to 'Shipping' (closes #274)

### DIFF
--- a/client/app/components/Store/CartSummary/index.js
+++ b/client/app/components/Store/CartSummary/index.js
@@ -16,7 +16,7 @@ const CartSummary = props => {
       <Container>
         <Row className='mb-2 summary-item'>
           <Col xs='9'>
-            <p className='summary-label'>Shippling</p>
+            <p className='summary-label'>Shipping</p>
           </Col>
           <Col xs='3' className='text-right'>
             <p className='summary-value'>Free</p>


### PR DESCRIPTION
## What does this PR do?
This pull request fixes a typo in the codebase where the word "Shipping" was misspelled as "Shippling" (issue #274).

Fixes #274