### PR TITLE
fix: updated footer to display account links instead of duplicate info

### DIFF
--- a/client/app/components/Common/Footer/index.js
+++ b/client/app/components/Common/Footer/index.js
@@ -4,33 +4,33 @@
  *
  */
 
-import React from 'react';
+import React from "react";
 
-import { Link } from 'react-router-dom';
-import { Container } from 'reactstrap';
+import { Link } from "react-router-dom";
+import { Container } from "reactstrap";
 
-import Newsletter from '../../../containers/Newsletter';
+import Newsletter from "../../../containers/Newsletter";
 
 const Footer = () => {
   const infoLinks = [
-    { id: 0, name: 'Contact Us', to: '/contact' },
-    { id: 1, name: 'Sell With Us', to: '/sell' },
-    { id: 2, name: 'Shipping', to: '/shipping' }
+    { id: 0, name: "Contact Us", to: "/contact" },
+    { id: 1, name: "Sell With Us", to: "/sell" },
+    { id: 2, name: "Shipping", to: "/shipping" },
   ];
 
   const footerBusinessLinks = (
-    <ul className='support-links'>
-      <li className='footer-link'>
-        <Link to='/dashboard'>Account Details</Link>
+    <ul className="support-links">
+      <li className="footer-link">
+        <Link to="/dashboard">Account Details</Link>
       </li>
-      <li className='footer-link'>
-        <Link to='/dashboard/orders'>Orders</Link>
+      <li className="footer-link">
+        <Link to="/dashboard/orders">Orders</Link>
       </li>
     </ul>
   );
 
-  const footerLinks = infoLinks.map(item => (
-    <li key={item.id} className='footer-link'>
+  const footerLinks = infoLinks.map((item) => (
+    <li key={item.id} className="footer-link">
       <Link key={item.id} to={item.to}>
         {item.name}
       </Link>
@@ -38,54 +38,54 @@ const Footer = () => {
   ));
 
   return (
-    <footer className='footer'>
+    <footer className="footer">
       <Container>
-        <div className='footer-content'>
-          <div className='footer-block'>
-            <div className='block-title'>
-              <h3 className='text-uppercase'>Customer Service</h3>
+        <div className="footer-content">
+          <div className="footer-block">
+            <div className="block-title">
+              <h3 className="text-uppercase">Customer Service</h3>
             </div>
-            <div className='block-content'>
+            <div className="block-content">
               <ul>{footerLinks}</ul>
             </div>
           </div>
-          <div className='footer-block'>
-            <div className='block-title'>
-              <h3 className='text-uppercase'>Links</h3>
+
+          <div className="footer-block">
+            <div className="block-title">
+              <h3 className="text-uppercase">Account</h3>
             </div>
-            <div className='block-content'>
-              <ul>{footerLinks}</ul>
-            </div>
+            <div className="block-content">{footerBusinessLinks}</div>
           </div>
-          <div className='footer-block'>
-            <div className='block-title'>
-              <h3 className='text-uppercase'>Newsletter</h3>
+
+          <div className="footer-block">
+            <div className="block-title">
+              <h3 className="text-uppercase">Newsletter</h3>
               <Newsletter />
             </div>
           </div>
         </div>
-        <div className='footer-copyright'>
+        <div className="footer-copyright">
           <span>© {new Date().getFullYear()} MERN Store</span>
         </div>
-        <ul className='footer-social-item'>
+        <ul className="footer-social-item">
           <li>
-            <a href='/#facebook' rel='noreferrer noopener' target='_blank'>
-              <span className='facebook-icon' />
+            <a href="/#facebook" rel="noreferrer noopener" target="_blank">
+              <span className="facebook-icon" />
             </a>
           </li>
           <li>
-            <a href='/#instagram' rel='noreferrer noopener' target='_blank'>
-              <span className='instagram-icon' />
+            <a href="/#instagram" rel="noreferrer noopener" target="_blank">
+              <span className="instagram-icon" />
             </a>
           </li>
           <li>
-            <a href='/#pinterest' rel='noreferrer noopener' target='_blank'>
-              <span className='pinterest-icon' />
+            <a href="/#pinterest" rel="noreferrer noopener" target="_blank">
+              <span className="pinterest-icon" />
             </a>
           </li>
           <li>
-            <a href='/#twitter' rel='noreferrer noopener' target='_blank'>
-              <span className='twitter-icon' />
+            <a href="/#twitter" rel="noreferrer noopener" target="_blank">
+              <span className="twitter-icon" />
             </a>
           </li>
         </ul>


### PR DESCRIPTION
## PR Title: fix: footer link duplication

### 📝 Description
Fixed a bug where the footer duplicated "Customer Service" links instead of showing "Account" links.

**Changes:**
- Enabled the unused `footerBusinessLinks` variable in the UI.
- Renamed the second column header to **"Account"**.
- Cleaned up redundant HTML tags.

**Impact:** Users can now access "Account Details" and "Orders" links from the footer.

---
**Type:** Bug fix